### PR TITLE
Add non-blocking analog read support

### DIFF
--- a/src/Indio.h
+++ b/src/Indio.h
@@ -63,7 +63,8 @@ class IndioClass
     int previous_sample;
     double mvDivisor;
     int startupState = 1;
-
+    unsigned long timer;
+    int oneShotPin = -1;
   public:
     
     
@@ -79,7 +80,11 @@ class IndioClass
     
  
 // read mcp342x data
-    float analogRead(int pin);
+    float analogRead(int pin=-1);
+    
+    void startAnalogConversion(int pin);
+    bool isAnalogConversionReady();
+
 //------------------------------------------------------------------------------
 // write mcp342x configuration byte
     int mcp342xWrite(int config);


### PR DESCRIPTION
Indio.analogRead() is very slow if multiple input channels are used sequentially (5ms...275ms).
It blocks the main loop for a while. This causes problems if you want to run real time tasks in the main loop. As a workaround I added three new functions to Indio class. You can now read analog inputs asynchronously.

Indio.startAnalogConversion(1 /*channel*/);
Indio.isAnalogConversionReady()
Indio.analogRead() //no parameters


Example code
```c++
#include <Indio.h>

void setup() {
  // put your setup code here, to run once:
  SerialUSB.begin(9600);

  Indio.setADCResolution(18); 
  Indio.analogReadMode(1, mA_p);
  Indio.analogReadMode(2, mA_p);
}

void loop() {
  static int state=0;
  switch(state) {
    case 0:
      Indio.startAnalogConversion(1); //Start conversion.  non-blocking function
      state++;
      break;
    case 1:
      if(Indio.isAnalogConversionReady()) { //true, if conversion is ready (267ms). non-blocking function
        SerialUSB.print("CH1: ");
        SerialUSB.println(Indio.analogRead()); //Takes only 600us. Normally this takes 267ms (Indio.analogRead(1))
        Indio.startAnalogConversion(2);  
        state++; 
      }
      break;
    case 2:
      if(Indio.isAnalogConversionReady()) {
        SerialUSB.print("CH2: ");
        SerialUSB.println(Indio.analogRead()); //Takes about 600us
        Indio.startAnalogConversion(1); //Start conversion
        state=1;
      }
      break;
  }
  // Run realtime tasks in here.
  // pwmTask();
}
```

